### PR TITLE
chore(appveyor): transfer the team and run test on Node v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ MIT License
 [npm-url]: https://npmjs.org/package/@kintone/plugin-manifest-validator
 [circleci-image]: https://circleci.com/gh/kintone/plugin-manifest-validator.svg?style=shield
 [circleci-url]: https://circleci.com/gh/kintone/plugin-manifest-validator
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/bsoep14h9y0m2a6x/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/teppeis/plugin-manifest-validator/branch/master
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/xduj1q65x80cxe3k/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/cybozu-frontend/plugin-manifest-validator/branch/master
 [deps-image]: https://img.shields.io/david/kintone/plugin-manifest-validator.svg
 [deps-url]: https://david-dm.org/kintone/plugin-manifest-validator
 [node-version]: https://img.shields.io/badge/Node.js%20support-v6,v8,v10-brightgreen.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "8"
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "10"
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -25,3 +27,8 @@ cache:
 
 # Just incremental build number
 version: "{build}"
+
+# https://github.com/kintone/webpack-plugin-kintone-plugin/pull/82
+branches:
+  only:
+    - master


### PR DESCRIPTION
This PR includes the following changes for Appveyor

* Transfer the Appveyor account to a team
* Run Appveyor on Node v8 and v10
* Running Appveyor for branches applies only for master.