### PR TITLE
ci: drop Node v6 and add Node v12 as a supporting version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,6 @@ commands:
       # run tests!
       - run: npm test
 jobs:
-  node-v6:
-    docker:
-      - image: circleci/node:6@sha256:52506adf0ce82ccdf8b652e07741c6796bf6730e305c0b6fb6068044dfb47035
-    steps:
-      - run-npm-test
   node-v8:
     docker:
       - image: circleci/node:8@sha256:cfa3ec6cb6fe2937aaa7323772ef76ecbbdd09ebb7a6f0e8efe9b1bbf652c720
@@ -33,10 +28,15 @@ jobs:
       - image: circleci/node:10@sha256:2b3e622e57b7d629110841a4bb2e46605227a80ebfebfbc806cc6a95270a398d
     steps:
       - run-npm-test
+  node-v12:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - run-npm-test
 
 workflows:
   multiple_builds:
     jobs:
-      - node-v6
       - node-v8
       - node-v10
+      - node-v12

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 os:
   - windows
 node_js:
-  - "6"
   - "8"
   - "10"
+  - "12"
 # running tests only when pushing a commit in master except PRs
 branches:
   only:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0-alpha.0",
   "author": "Teppei Sato <teppeis@gmail.com>",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "index.js",
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: drop Node v6 support